### PR TITLE
move remaining CMake files for tests into associated subdirectories

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,23 +13,8 @@ add_boost_test_core(${ARGV})
 set_source_files_properties( ${source} PROPERTIES COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK )
 endmacro(add_boost_test)
 
-add_boost_test( foreach vm/foreach.cpp )
-
+add_subdirectory(vm)
 add_subdirectory(frontend)
-
-add_boost_test( traits model/traits.cpp )
-add_boost_test( render_traits model/render_traits.cpp )
-
-# The second test style spans two source files, one of which defines BOOST_TEST_DYN_LINK internally,
-# so we don't need to set that.  However, the tests expect to be in a particular working directory
-# and will fail if we don't execute from there
-macro(add_boost_test_twopart name source)
-add_boost_test_core(${ARGV})
-set_tests_properties( ${name} PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
-endmacro(add_boost_test_twopart)
-
-add_boost_test_twopart( mustache_parser mustache/mustache_parser.cpp shared/parser_test.cpp )
-add_boost_test_twopart( mustache_compiler mustache/mustache_compiler.cpp shared/parser_test.cpp )
-add_boost_test_twopart( mustache_end2end mustache/mustache_end2end.cpp shared/parser_test.cpp )
-
-
+add_subdirectory(model)
+# The second test style is defined and used exclusively within the "mustache" directory
+add_subdirectory(mustache)

--- a/test/model/CMakeLists.txt
+++ b/test/model/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_boost_test( traits traits.cpp )
+add_boost_test( render_traits render_traits.cpp )

--- a/test/mustache/CMakeLists.txt
+++ b/test/mustache/CMakeLists.txt
@@ -1,0 +1,11 @@
+# The second test style spans two source files, one of which defines BOOST_TEST_DYN_LINK internally,
+# so we don't need to set that.  However, the tests expect to be in a particular working directory
+# and will fail if we don't execute from there
+macro(add_boost_test_twopart name source)
+add_boost_test_core(${ARGV})
+set_tests_properties( ${name} PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.. )
+endmacro(add_boost_test_twopart)
+
+add_boost_test_twopart( mustache_parser mustache_parser.cpp ../shared/parser_test.cpp )
+add_boost_test_twopart( mustache_compiler mustache_compiler.cpp ../shared/parser_test.cpp )
+add_boost_test_twopart( mustache_end2end mustache_end2end.cpp ../shared/parser_test.cpp )

--- a/test/vm/CMakeLists.txt
+++ b/test/vm/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_boost_test( foreach foreach.cpp )


### PR DESCRIPTION
I should have done this with the previous PR... this change adds control files for the other three test subdirectories to match the planned changes in the Boost Build control structure.