### PR TITLE
Add support for partials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.53 COMPONENTS unit_test_framework system filesystem)
 
-add_definitions( -DBOOST_SPIRIT_USE_PHOENIX_V3=1 )
+add_definitions( -DBOOST_SPIRIT_USE_PHOENIX_V3=1 -DBOOST_TEST_ALTERNATIVE_INIT_API )
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   add_definitions( -std=c++0x -ftemplate-depth=512 -Wno-unused-local-typedefs -Wno-deprecated-declarations )
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,4 +2,4 @@ foreach( EXAMPLE example1 example2 example3 )
   add_executable( ${EXAMPLE} ${EXAMPLE}.cpp )
 endforeach()
 
-
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/footer.mst ${CMAKE_CURRENT_BINARY_DIR}/footer.mst COPYONLY)

--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -4,7 +4,6 @@
  *  A simple example of how to use boostache.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -4,6 +4,7 @@
  *  A simple example of how to use boostache.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,6 +12,7 @@
 #define BOOST_SPIRIT_NO_PREDEFINED_TERMINALS
 
 #include <boost/boostache/boostache.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 #include <boost/boostache/frontend/stache/grammar_def.hpp> // need to work out header only syntax
 #include <boost/boostache/stache.hpp>
 #include <boost/boostache/model/helper.hpp>
@@ -45,7 +47,7 @@ int main()
    using boostache::load_template;
 
    auto iter = input.begin();
-   auto templ = load_template<boostache::format::stache>(iter, input.end());
+   auto templ = load_template<boostache::format::stache>(iter, input.end(), boostache::frontend::file_mapper<char>());
    // ------------------------------------------------------------------
 
    // ------------------------------------------------------------------

--- a/examples/example2.cpp
+++ b/examples/example2.cpp
@@ -4,7 +4,6 @@
  *  A slightly more complex example.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/examples/example2.cpp
+++ b/examples/example2.cpp
@@ -4,6 +4,7 @@
  *  A slightly more complex example.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,6 +14,7 @@
 #include <boost/boostache/boostache.hpp>
 #include <boost/boostache/frontend/stache/grammar_def.hpp> // need to work out header only syntax
 #include <boost/boostache/stache.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 #include <boost/boostache/model/helper.hpp>
 #include <iostream>
 #include <sstream>
@@ -24,7 +26,7 @@ namespace boostache = boost::boostache;
 // -------------------------------------------------------
 // The data will be an invoice this time. The invoice
 // consists of a list of line items. Each line item
-// can be describes as map of string to strings.
+// can be described as map of string to strings.
 //
 using item_t = std::map<std::string, std::string>;
 using item_list_t = std::vector<item_t>;
@@ -36,7 +38,7 @@ int main()
 {
    // ------------------------------------------------------------------
    // The template describing an invoice.
-   std::string input( 
+   std::string input(
                       "Invoice"
                       "\n"
                       "{{#lines}}"
@@ -49,13 +51,13 @@ int main()
    // ------------------------------------------------------------------
    // The data description. invoice_items is a list of maps that
    // describe each item.
-   item_list_t invoice_items = { 
+   item_list_t invoice_items = {
                                  { {"item_code"    , "1234"},
                                    {"description"  , "teddy bear"},
                                    {"amount"       , "$23"} },
                                  { {"item_code"    , "1235"},
                                    {"description"  , "computer"},
-                                   {"amount"       , "$9"} } 
+                                   {"amount"       , "$9"} }
    };
 
    // we need to put the list into a map so that tag 'lines' can
@@ -70,7 +72,7 @@ int main()
    using boostache::load_template;
 
    auto iter = input.begin();
-   auto templ = load_template<boostache::format::stache>(iter, input.end());
+   auto templ = load_template<boostache::format::stache>(iter, input.end(), boostache::frontend::file_mapper<char>());
    // ------------------------------------------------------------------
 
    // ------------------------------------------------------------------

--- a/examples/example3.cpp
+++ b/examples/example3.cpp
@@ -38,6 +38,8 @@ namespace boostache = boost::boostache;
 // This is fairly simple to do with a variant. We are going
 // to use the spirit version of it because it makes
 // recursive structures easier to describe.
+// We also add a partial at the end. Note that the partial
+// itself can contain more boostache (see footer.mst).
 //
 
 struct value_t;
@@ -63,7 +65,7 @@ int main()
    // ------------------------------------------------------------------
    // The template describing an invoice.
    std::string input(
-                      "Invoice {{invoice_number}}"
+                      "Invoice {{invoice_number}}\n"
                       "\n"
                       "{{# company}}"
                       "Company: {{name}}\n"
@@ -73,7 +75,8 @@ int main()
                       "------------------------------------------------\n"
                       "{{#lines}}"
                       "  {{item_code}}  {{description}}  {{amount}}\n"
-                      "{{/lines}}"
+                      "{{/lines}}\n"
+                      "- {{>footer}} -"
       );
    // ------------------------------------------------------------------
 
@@ -105,8 +108,16 @@ int main()
    using boostache::load_template;
    using boostache::frontend::file_mapper;
 
+   //The file mapper coming with boostache  will try to read from a file
+   //called <work_dir>/<partial_name>.<ext>
+   //By default work_dir is the empty string (current directory), and ext
+   //is ".mustache". In this example we change it to ".mst".
+   //You can customize how partials are resolved by providing your own
+   //mapper.
+   boostache::frontend::file_mapper<char> fmapper(".mst");
+
    auto iter = input.begin();
-   auto templ = load_template<boostache::format::stache>(iter, input.end(), file_mapper<char>());
+   auto templ = load_template<boostache::format::stache>(iter, input.end(), fmapper);
    // ------------------------------------------------------------------
 
    // ------------------------------------------------------------------

--- a/examples/example3.cpp
+++ b/examples/example3.cpp
@@ -5,6 +5,7 @@
  *  clean things up with a variant.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +15,7 @@
 #include <boost/boostache/boostache.hpp>
 #include <boost/boostache/frontend/stache/grammar_def.hpp> // need to work out header only syntax
 #include <boost/boostache/stache.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 #include <boost/boostache/model/helper.hpp>
 #include <boost/spirit/include/support_extended_variant.hpp>
 #include <string>
@@ -60,7 +62,7 @@ int main()
 {
    // ------------------------------------------------------------------
    // The template describing an invoice.
-   std::string input( 
+   std::string input(
                       "Invoice {{invoice_number}}"
                       "\n"
                       "{{# company}}"
@@ -79,7 +81,7 @@ int main()
    // ------------------------------------------------------------------
    // The data description.
 
-   object_t invoice = 
+   object_t invoice =
       {{"invoice_number", "1234"},
        {"company"       , object_t{{"name"   , "FizSoft"},
                                    {"street" , "42 Level St."},
@@ -93,7 +95,7 @@ int main()
                                            {"description"  , "Computer"},
                                            {"amount"       , "$9"}}   }}
    };
-                                                      
+
    // ------------------------------------------------------------------
 
    // ------------------------------------------------------------------
@@ -101,9 +103,10 @@ int main()
    // This parses the input and compiles the result. The return is the
    // compiled data structure
    using boostache::load_template;
+   using boostache::frontend::file_mapper;
 
    auto iter = input.begin();
-   auto templ = load_template<boostache::format::stache>(iter, input.end());
+   auto templ = load_template<boostache::format::stache>(iter, input.end(), file_mapper<char>());
    // ------------------------------------------------------------------
 
    // ------------------------------------------------------------------

--- a/examples/example3.cpp
+++ b/examples/example3.cpp
@@ -5,7 +5,6 @@
  *  clean things up with a variant.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/examples/footer.mst
+++ b/examples/footer.mst
@@ -1,0 +1,1 @@
+End of invoice {{invoice_number}}

--- a/include/boost/boostache/backend/detail/stache_compiler.hpp
+++ b/include/boost/boostache/backend/detail/stache_compiler.hpp
@@ -2,6 +2,7 @@
  *  \file detail/stache_compiler.hpp
  *
  *  Copyright 2014, 2015 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -28,7 +29,7 @@ namespace boost { namespace boostache { namespace backend { namespace stache_com
          return( s.find_first_not_of(std::string{" \t\r\n"})
                  ==  std::string::npos );
       }
-      
+
       class stache_visit
       {
       public:
@@ -103,13 +104,17 @@ namespace boost { namespace boostache { namespace backend { namespace stache_com
          vm::ast::node operator()(fe::stache::ast::comment const & v) const
          {
             return vm::ast::nop{};
-         }         
+         }
 
-         vm::ast::node operator()(fe::stache::ast::partial const & v) const
+         vm::ast::node operator()(fe::stache::ast::partial const & p) const
          {
-            // TODO: need to implement partials
-            return vm::ast::nop{};
-         }         
+            vm::ast::node_list node_list;
+            for (auto const & node : p.nodes)
+            {
+               node_list.nodes.push_back(boost::apply_visitor(*this, node));
+            }
+            return node_list;
+         }
 
          vm::ast::node operator()(fe::stache::ast::node_list const & nodes) const
          {

--- a/include/boost/boostache/boostache.hpp
+++ b/include/boost/boostache/boostache.hpp
@@ -2,6 +2,7 @@
  *  \file boostache.hpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,20 +15,21 @@
 #include <boost/boostache/backend/stache_compiler.hpp>
 #include <boost/boostache/vm/generate.hpp>
 #include <istream>
+#include <utility>
 
 
 namespace boost { namespace boostache
 {
-   template <typename Format, typename Iterator>
-   inline vm::ast::node load_template(Iterator & begin, Iterator const & end)
+   template <typename Format, typename Iterator, typename PartialFunctor>
+   inline vm::ast::node load_template(Iterator & begin, Iterator const & end, PartialFunctor mapper_type)
    {
-      return backend::compile(frontend::parse<Format>(begin,end));
+      return backend::compile(frontend::parse<Format>(begin,end, std::move(mapper_type)));
    }
 
-   template <typename Format>
-   inline vm::ast::node load_template(std::istream & input)
+   template <typename Format, typename PartialFunctor>
+   inline vm::ast::node load_template(std::istream & input, PartialFunctor mapper_type)
    {
-      return backend::compile(frontend::parse<Format>(input));
+      return backend::compile(frontend::parse<Format>(input, std::move(mapper_type)));
    }
 
    template <typename Stream, typename Context>

--- a/include/boost/boostache/boostache.hpp
+++ b/include/boost/boostache/boostache.hpp
@@ -2,7 +2,6 @@
  *  \file boostache.hpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/boostache/frontend/file_mapper.hpp
+++ b/include/boost/boostache/frontend/file_mapper.hpp
@@ -1,0 +1,67 @@
+/**
+ *  \file file_mapper.hpp
+ *
+ *  Copyright 2015 Michele Santullo
+ *
+ *  Utility class that maps a partial name to a file on the filesystem.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_BOOSTACHE_FILE_MAPPER_HPP
+#define BOOST_BOOSTACHE_FILE_MAPPER_HPP
+
+#include <string>
+#include <utility>
+#include <fstream>
+
+namespace boost { namespace boostache { namespace frontend
+{
+template <typename CharType>
+class file_mapper
+{
+public:
+   using string_type = std::basic_string<CharType>;
+
+   file_mapper (file_mapper&&) = default;
+   file_mapper (const file_mapper&) = default;
+   explicit file_mapper (string_type&& ext=".mustache", string_type&& base_path="") :
+      extension(std::move(ext)),
+      base_path(std::move(base_path))
+   {
+   }
+
+   void set_extension (string_type&& ext)
+   {
+      extension = std::move(ext);
+   }
+   void set_base_path (string_type&& bpath)
+   {
+      base_path = std::move(bpath);
+      if (!base_path.empty() && base_path.back() != static_cast<CharType>('/') && base_path.back() != static_cast<CharType>('\\'))
+         base_path += '/';
+   }
+
+   string_type operator() (const string_type& tag) const
+   {
+      //TODO: don't open the file every time, add some sort of buffering instead
+      string_type path(base_path + tag + extension);
+      std::basic_ifstream<CharType> ifs(path);
+      ifs.seekg(0, std::ios_base::end);
+      const auto ssize = ifs.tellg();
+      ifs.seekg(0, std::ios_base::beg);
+
+      string_type retval;
+      retval.resize(ssize, ' ');
+      ifs.read(&*retval.begin(), ssize);
+      ifs.close();
+      return retval;
+   }
+
+private:
+   string_type extension;
+   string_type base_path;
+};
+}}}
+#endif

--- a/include/boost/boostache/frontend/parse.hpp
+++ b/include/boost/boostache/frontend/parse.hpp
@@ -2,7 +2,6 @@
  *  \file parse.hpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Generic parser entry point. Call parse with the input format
  *  as the template parameter:

--- a/include/boost/boostache/frontend/parse.hpp
+++ b/include/boost/boostache/frontend/parse.hpp
@@ -2,6 +2,7 @@
  *  \file parse.hpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Generic parser entry point. Call parse with the input format
  *  as the template parameter:
@@ -17,15 +18,16 @@
 #include <boost/spirit/include/qi_parse.hpp>
 #include <boost/spirit/include/support_istream_iterator.hpp>
 #include <iostream>
+#include <utility>
 
 namespace boost { namespace boostache { namespace frontend
 {
-   template <typename Format, typename Iterator>
-   typename Format::ast_t parse(Iterator & begin, Iterator const & end)
+   template <typename Format, typename Iterator, typename PartialFunctor>
+   typename Format::ast_t parse(Iterator & begin, Iterator const & end, PartialFunctor mapper_type)
    {
       typename Format::ast_t ast;
-      typename Format::template grammar_t<Iterator> grammar;
-      
+      typename Format::template grammar_t<Iterator, PartialFunctor> grammar(std::move(mapper_type));
+
       // TODO mjc : should throw with parse error location
       if(!boost::spirit::qi::phrase_parse( begin, end
                                          , grammar
@@ -38,14 +40,15 @@ namespace boost { namespace boostache { namespace frontend
    }
 
 
-   template <typename Format>
-   typename Format::ast_t parse(std::istream& input)
+   template <typename Format, typename PartialFunctor>
+   typename Format::ast_t parse(std::istream& input, PartialFunctor mapper_type)
    {
       // TODO mjc : store/restore ios state?
       input.unsetf(std::ios::skipws);
       boost::spirit::istream_iterator iter{input};
       return parse<Format>( iter
-                          , boost::spirit::istream_iterator{} );
+                          , boost::spirit::istream_iterator{}
+                          , std::move(mapper_type) );
    }
 }}}
 

--- a/include/boost/boostache/frontend/stache/ast.hpp
+++ b/include/boost/boostache/frontend/stache/ast.hpp
@@ -3,6 +3,7 @@
  *
  *  Copyright 2014 Michael Caisse : ciere.com
  *  Copyright 2014 Jeroen Habraken
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -34,9 +35,7 @@ namespace boost { namespace boostache { namespace frontend { namespace stache { 
       identifier value;
    };
 
-   struct partial : identifier
-   {};
-
+   struct partial;
    struct section;
 
    struct node : boost::spirit::extended_variant<
@@ -45,7 +44,7 @@ namespace boost { namespace boostache { namespace frontend { namespace stache { 
       , literal_text
       , variable
       , boost::recursive_wrapper<section>
-      , partial
+      , boost::recursive_wrapper<partial>
       >
    {
       node() : base_type() {}
@@ -61,6 +60,12 @@ namespace boost { namespace boostache { namespace frontend { namespace stache { 
    struct section
    {
       bool is_inverted;
+      identifier name;
+      node_list nodes;
+   };
+
+   struct partial
+   {
       identifier name;
       node_list nodes;
    };

--- a/include/boost/boostache/frontend/stache/grammar.hpp
+++ b/include/boost/boostache/frontend/stache/grammar.hpp
@@ -3,7 +3,6 @@
  *
  *  Copyright 2014 Michael Caisse : ciere.com
  *  Copyright 2014 Jeroen Habraken
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/boostache/frontend/stache/grammar.hpp
+++ b/include/boost/boostache/frontend/stache/grammar.hpp
@@ -3,6 +3,7 @@
  *
  *  Copyright 2014 Michael Caisse : ciere.com
  *  Copyright 2014 Jeroen Habraken
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,17 +15,20 @@
 
 #include <boost/spirit/include/qi_char_class.hpp>
 #include <boost/spirit/include/qi_rule.hpp>
+#include <string>
+#include <boost/fusion/support/unused.hpp>
 
 
 namespace boost { namespace boostache { namespace frontend { namespace stache
 {
    namespace qi = boost::spirit::qi;
 
-   template <typename Iterator>
+   template <typename Format, typename Iterator, typename PartialFunctor>
    struct grammar
       : qi::grammar<Iterator, ast::node_list(), qi::space_type>
    {
-      grammar();
+      explicit grammar(PartialFunctor&& partial_mapper);
+      explicit grammar(const PartialFunctor& partial_mapper);
 
       qi::rule<Iterator, ast::node_list(), qi::space_type>
          node_list
@@ -69,6 +73,11 @@ namespace boost { namespace boostache { namespace frontend { namespace stache
       qi::rule<Iterator, ast::partial(), qi::space_type>
          partial
          ;
+
+   private:
+      ast::partial on_partial (const ast::identifier& name, const boost::fusion::unused_type& context, bool& pass) const;
+
+      PartialFunctor partial_mapper;
    };
 }}}}
 

--- a/include/boost/boostache/frontend/stache/printer.hpp
+++ b/include/boost/boostache/frontend/stache/printer.hpp
@@ -3,7 +3,6 @@
  *
  *  Copyright 2014 Michael Caisse : ciere.com
  *  Copyright 2014 Jeroen Habraken
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/boostache/frontend/stache/printer.hpp
+++ b/include/boost/boostache/frontend/stache/printer.hpp
@@ -3,6 +3,7 @@
  *
  *  Copyright 2014 Michael Caisse : ciere.com
  *  Copyright 2014 Jeroen Habraken
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -67,7 +68,7 @@ namespace boost { namespace boostache { namespace frontend { namespace stache { 
 
          void operator()(partial const & v) const
          {
-            out << "{{>" << v << "}}";
+            out << "{{>" << v.name << "}}";
          }
 
       private:

--- a/include/boost/boostache/stache.hpp
+++ b/include/boost/boostache/stache.hpp
@@ -2,7 +2,6 @@
  *  \file stache.hpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/include/boost/boostache/stache.hpp
+++ b/include/boost/boostache/stache.hpp
@@ -2,6 +2,7 @@
  *  \file stache.hpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,8 +19,8 @@ namespace boost { namespace boostache { namespace format
 {
    struct stache
    {
-      template <typename Iterator>
-      using grammar_t = frontend::stache::grammar<Iterator>;
+      template <typename Iterator, typename PartialFunctor>
+      using grammar_t = frontend::stache::grammar<stache, Iterator, PartialFunctor>;
 
       using ast_t = frontend::stache::ast::root;
       using skipper_t = boost::spirit::qi::space_type;

--- a/test/frontend/CMakeLists.txt
+++ b/test/frontend/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_boost_test(adapt_test adapt_test.cpp)
 add_boost_test(grammar_basic grammar_basic.cpp)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/partial.mustache ${CMAKE_CURRENT_BINARY_DIR}/partial.mustache COPYONLY)

--- a/test/frontend/adapt_test.cpp
+++ b/test/frontend/adapt_test.cpp
@@ -1,6 +1,7 @@
 // file used during initial dev
 // will be removed
 #include <boost/boostache/frontend/parse.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 #include <boost/boostache/stache.hpp>
 #include <boost/boostache/frontend/stache/grammar_def.hpp>
 #include <string>
@@ -12,6 +13,7 @@ using boostache::frontend::parse;
 int main()
 {
    std::string input("foo");
+   boostache::frontend::file_mapper<char> fmapper;
    auto iter = input.begin();
-   auto ast = parse<boostache::format::stache>(iter,input.end());
+   auto ast = parse<boostache::format::stache>(iter,input.end(), fmapper);
 }

--- a/test/frontend/grammar_basic.cpp
+++ b/test/frontend/grammar_basic.cpp
@@ -2,7 +2,6 @@
  *  \file frontend/grammar_basic.cpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Basic stache gramar test
  *

--- a/test/frontend/grammar_basic.cpp
+++ b/test/frontend/grammar_basic.cpp
@@ -2,6 +2,7 @@
  *  \file frontend/grammar_basic.cpp
  *
  *  Copyright 2014 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Basic stache gramar test
  *
@@ -14,6 +15,7 @@
 #include <boost/boostache/stache.hpp>
 #include <boost/boostache/frontend/stache/grammar_def.hpp>
 #include <boost/boostache/frontend/stache/printer.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 
 #include <sstream>
 #include <string>
@@ -41,7 +43,7 @@ BOOST_AUTO_TEST_CASE(stache_parse_test)
       );
 
    auto iter = input.begin();
-   auto ast = parse<boostache::format::stache>(iter,input.end());
+   auto ast = parse<boostache::format::stache>(iter,input.end(), boostache::frontend::file_mapper<char>());
 
    // we expect everything got parsed
    BOOST_CHECK(iter==input.end());

--- a/test/frontend/partial.mustache
+++ b/test/frontend/partial.mustache
@@ -1,0 +1,1 @@
+replacement for partial

--- a/test/mustache/mustache_compiler.cpp
+++ b/test/mustache/mustache_compiler.cpp
@@ -4,6 +4,7 @@
  *  Link with shared/parser_test to utilize loading and parsing test files.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,6 +13,7 @@
 #include <boost/boostache/stache.hpp>
 #include <boost/boostache/frontend/stache/grammar_def.hpp>
 #include <boost/boostache/frontend/parse.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 
 #include <boost/boostache/backend/stache_compiler.hpp>
 #include <boost/boostache/vm/printer.hpp>
@@ -33,7 +35,7 @@ std::string print_ast(std::string const & filename)
    }
 
    std::ifstream istream(filename.c_str());
-   auto ast = fe::parse<boostache::format::stache>(istream);
+   auto ast = fe::parse<boostache::format::stache>(istream, boostache::frontend::file_mapper<char>());
    auto engine_ast = boostache::backend::compile(ast);
 
    std::ostringstream stream;

--- a/test/mustache/mustache_compiler.cpp
+++ b/test/mustache/mustache_compiler.cpp
@@ -4,7 +4,6 @@
  *  Link with shared/parser_test to utilize loading and parsing test files.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/mustache/mustache_end2end.cpp
+++ b/test/mustache/mustache_end2end.cpp
@@ -4,6 +4,7 @@
  *  Link with shared/parser_test to utilize loading and parsing test files.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,6 +13,7 @@
 #include <boost/spirit/include/support_extended_variant.hpp>
 
 #include <boost/boostache/boostache.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 #include <boost/boostache/frontend/stache/grammar_def.hpp> // need to work out header only syntax
 #include <boost/boostache/stache.hpp>
 #include <boost/boostache/model/stache_model.hpp>
@@ -92,7 +94,7 @@ std::string print_ast(std::string const & filename)
    // ------------------------------------------------------------------
 
    // load and compile the template
-   auto templ = boostache::load_template<boostache::format::stache>(file);
+   auto templ = boostache::load_template<boostache::format::stache>(file, boostache::frontend::file_mapper<char>());
    std::ostringstream stream;
    boostache::generate(stream, templ, data);
    return stream.str();

--- a/test/mustache/mustache_end2end.cpp
+++ b/test/mustache/mustache_end2end.cpp
@@ -4,7 +4,6 @@
  *  Link with shared/parser_test to utilize loading and parsing test files.
  *
  *  Copyright 2015 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/mustache/mustache_parser.cpp
+++ b/test/mustache/mustache_parser.cpp
@@ -4,6 +4,7 @@
  *  Link with shared/parser_test to test the mustache parser
  *
  *  Copyright 2015 Michael Caisse : ciere.com
+ *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +15,7 @@
 #include <boost/boostache/frontend/stache/grammar_def.hpp>
 #include <boost/boostache/frontend/stache/ast.hpp>
 #include <boost/boostache/frontend/stache/printer.hpp>
+#include <boost/boostache/frontend/file_mapper.hpp>
 #include <boost/boostache/frontend/parse.hpp>
 #include <string>
 #include <sstream>
@@ -32,7 +34,7 @@ std::string print_ast(std::string const & filename)
    }
 
    std::ifstream istream(filename.c_str());
-   auto ast = fe::parse<bstache::format::stache>(istream);
+   auto ast = fe::parse<bstache::format::stache>(istream, bstache::frontend::file_mapper<char>());
    std::ostringstream stream;
    fe::stache::ast::print(stream,ast);
    return stream.str();

--- a/test/mustache/mustache_parser.cpp
+++ b/test/mustache/mustache_parser.cpp
@@ -4,7 +4,6 @@
  *  Link with shared/parser_test to test the mustache parser
  *
  *  Copyright 2015 Michael Caisse : ciere.com
- *  Copyright 2015 Michele Santullo
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
As discussed those commits add support for partials. Unfortunately client code has to pass one additional parameter down to the parser, but at the price of always including file_mapper.hpp we can provide overloads that will default to file_mapper whenever it's not specified. I suspect that's going to be the most common case, anyways.
Please let me know if the style is good enough and if you think this is the correct approach.