### PR TITLE
C++11 patch

### DIFF
--- a/include/boost/boostache/model/unwrap_variant.hpp
+++ b/include/boost/boostache/model/unwrap_variant.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace boostache { namespace extension
             , variant_attribute)
    {
       return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor<bool>(
-                                      [&tag](auto ctx)
+                                      [&tag](T const & ctx)
                                       {
                                          return test(ctx, tag);
                                       }
@@ -38,7 +38,7 @@ namespace boost { namespace boostache { namespace extension
             , variant_attribute)
    {
       return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor<bool>(
-                                      [](auto ctx)
+                                      [](T const & ctx)
                                       {
                                          return test(ctx);
                                       }
@@ -51,8 +51,8 @@ namespace boost { namespace boostache { namespace extension
    void render( Stream & stream, T const & context, std::string const & name
               , variant_attribute)
    {
-      return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
-                                      [&stream,&name](auto ctx)
+      boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
+                                      [&stream,&name](T const& ctx)
                                       {
                                          render(stream,ctx,name);
                                       }

--- a/include/boost/boostache/vm/detail/foreach.hpp
+++ b/include/boost/boostache/vm/detail/foreach.hpp
@@ -101,7 +101,7 @@ namespace boost { namespace boostache { namespace vm { namespace detail
                , extension::variant_attribute)
    {
       boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
-                               [&stream,&node](auto ctx)
+                               [&stream,&node](Context const & ctx)
                                {
                                   vm::detail::foreach(stream, node, ctx);
                                }

--- a/include/boost/boostache/vm/detail/select_context.hpp
+++ b/include/boost/boostache/vm/detail/select_context.hpp
@@ -63,7 +63,7 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       boost::apply_visitor(
          boostache::detail::make_unwrap_variant_visitor(
-            [&stream,&templ,&ctx_parent](auto ctx)
+            [&stream,&templ,&ctx_parent](Context2 const & ctx)
             {
                select_context( stream, templ, ctx_parent, ctx
                              , extension::select_category_t<decltype(ctx)>{});
@@ -89,7 +89,7 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       boost::apply_visitor(
          boostache::detail::make_unwrap_variant_visitor(
-            [&stream,&templ](auto ctx)
+            [&stream,&templ](Context const & ctx)
             {
                select_context_dispatch( stream, templ, ctx
                                       , extension::select_category_t<decltype(ctx)>{});

--- a/test/frontend/grammar_basic.cpp
+++ b/test/frontend/grammar_basic.cpp
@@ -17,6 +17,7 @@
 
 #include <sstream>
 #include <string>
+#include <boost/algorithm/cxx14/mismatch.hpp>
 
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
@@ -62,7 +63,7 @@ BOOST_AUTO_TEST_CASE(stache_parse_test)
       );
 
    auto input_ast = stream.str();
-   auto diff_iters = std::mismatch(input_ast.begin(), input_ast.end(),
+   auto diff_iters = boost::algorithm::mismatch(input_ast.begin(), input_ast.end(),
                                    expected.begin(), expected.end());
 
    if(std::get<0>(diff_iters) != input_ast.end())

--- a/test/shared/parser_test.cpp
+++ b/test/shared/parser_test.cpp
@@ -19,6 +19,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/parameterized_test.hpp>
+#include <boost/algorithm/cxx14/mismatch.hpp>
 #include <string>
 #include <fstream>
 #include <iostream>
@@ -49,7 +50,7 @@ void test_parse(std::string const & filename)
    std::string expected( std::istreambuf_iterator<char>{expect_stream}
                        , std::istreambuf_iterator<char>{});
 
-   auto diff_iters = std::mismatch(input_ast.begin(), input_ast.end(),
+   auto diff_iters = boost::algorithm::mismatch(input_ast.begin(), input_ast.end(),
                                    expected.begin(), expected.end());
 
    if(std::get<0>(diff_iters) != input_ast.end())


### PR DESCRIPTION
Changes for C++11 compatibility:
- Replace auto with generic parameters in templates
- std::mismatch -> boost::algorithm::mismatch (only tests affected)