### PR TITLE
C++11 patch

### DIFF
--- a/include/boost/boostache/model/unwrap_variant.hpp
+++ b/include/boost/boostache/model/unwrap_variant.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace boostache { namespace extension
             , variant_attribute)
    {
       return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor<bool>(
-                                      [&tag](auto ctx)
+                                      [&tag](T const & ctx)
                                       {
                                          return test(ctx, tag);
                                       }
@@ -38,7 +38,7 @@ namespace boost { namespace boostache { namespace extension
             , variant_attribute)
    {
       return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor<bool>(
-                                      [](auto ctx)
+                                      [](T const & ctx)
                                       {
                                          return test(ctx);
                                       }
@@ -51,8 +51,8 @@ namespace boost { namespace boostache { namespace extension
    void render( Stream & stream, T const & context, std::string const & name
               , variant_attribute)
    {
-      return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
-                                      [&stream,&name](auto ctx)
+      boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
+                                      [&stream,&name](T const& ctx)
                                       {
                                          render(stream,ctx,name);
                                       }

--- a/include/boost/boostache/model/unwrap_variant.hpp
+++ b/include/boost/boostache/model/unwrap_variant.hpp
@@ -19,43 +19,86 @@
 
 namespace boost { namespace boostache { namespace extension
 {
+#ifdef BOOSTACHE_USE_CPP11
+template<class Tag>
+struct Cpp11GenericLamdaSimulation_test_tag
+{
+    const Tag& tag;
+    Cpp11GenericLamdaSimulation_test_tag(const Tag& tag):tag(tag){}
+    template<class T>
+    bool operator()(const T& ctx)const{
+        return test(ctx,tag);
+    }
+};
+#endif
    template <typename T>
    bool test( T const & context, std::string const & tag
             , variant_attribute)
    {
       return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor<bool>(
-                                      [&tag](T const & ctx)
+                                 #ifdef BOOSTACHE_USE_CPP11
+                                   Cpp11GenericLamdaSimulation_test_tag<std::string>(tag)
+                                 #else
+                                      [&tag](auto ctx)
                                       {
-                                         return test(ctx, tag);
+                                          return test(ctx,tag);
                                       }
+                                 #endif
                                    )
                                  , context);
    }
-
-
+#ifdef BOOSTACHE_USE_CPP11
+   struct Cpp11GenericLamdaSimulation_test
+   {
+       template<class T>
+       bool operator()(const T& ctx)const{
+           return test(ctx);
+       }
+   };
+#endif
    template <typename T>
    bool test( T const & context
             , variant_attribute)
    {
       return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor<bool>(
-                                      [](T const & ctx)
-                                      {
-                                         return test(ctx);
-                                      }
+                                 #ifdef BOOSTACHE_USE_CPP11
+                                         Cpp11GenericLamdaSimulation_test{}
+                                 #else
+                                       [](auto ctx)
+                                    {
+                                       return test(ctx);
+                                    }
+                                 #endif
                                    )
                                  , context);
    }
-
+#ifdef BOOSTACHE_USE_CPP11
+   template<class Stream,class Name, class R = void>
+   struct Cpp11GenericLamdaSimulation_render_stream_name
+   {
+       Stream& stream;
+       Name& name;
+       Cpp11GenericLamdaSimulation_render_stream_name(Stream& stream,Name& name):stream(stream),name(name){}
+       template<class T>
+       R operator()(const T& ctx)const{
+           return render(stream,ctx,name);
+       }
+   };
+#endif
 
    template< typename Stream, typename T >
    void render( Stream & stream, T const & context, std::string const & name
               , variant_attribute)
    {
-      boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
-                                      [&stream,&name](T const& ctx)
-                                      {
-                                         render(stream,ctx,name);
-                                      }
+       return boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
+                                 #ifdef BOOSTACHE_USE_CPP11
+                                      Cpp11GenericLamdaSimulation_render_stream_name<Stream,std::string const>(stream,name)
+                                 #else
+                                   [&stream,&name](auto ctx)
+                                   {
+                                      render(stream,ctx,name);
+                                   }
+                                 #endif
                                    )
                                  , context);
    }

--- a/include/boost/boostache/vm/detail/foreach.hpp
+++ b/include/boost/boostache/vm/detail/foreach.hpp
@@ -92,7 +92,19 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       generate(stream, node.value, context);
    }
-
+#ifdef BOOSTACHE_USE_CPP11
+   template<class Stream,class Node>
+   struct Cpp11GenericLamdaSimulation_foreach
+   {
+       Stream& stream;
+       const Node& node;
+       Cpp11GenericLamdaSimulation_foreach(Stream& stream,const Node& node):stream(stream),node(node){}
+       template<class T>
+       void operator()(const T& ctx)const{
+           vm::detail::foreach(stream, node, ctx);
+       }
+   };
+#endif
 
    template <typename Stream, typename Node, typename Context>
    void foreach( Stream & stream
@@ -101,10 +113,14 @@ namespace boost { namespace boostache { namespace vm { namespace detail
                , extension::variant_attribute)
    {
       boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
-                               [&stream,&node](Context const & ctx)
+                          #ifdef BOOSTACHE_USE_CPP11
+                               Cpp11GenericLamdaSimulation_foreach<Stream,Node>(stream,node)
+                          #else
+                                [&stream,&node](auto ctx)
                                {
                                   vm::detail::foreach(stream, node, ctx);
                                }
+                          #endif
                             )
                           , context);
    }

--- a/include/boost/boostache/vm/detail/foreach.hpp
+++ b/include/boost/boostache/vm/detail/foreach.hpp
@@ -101,7 +101,7 @@ namespace boost { namespace boostache { namespace vm { namespace detail
                , extension::variant_attribute)
    {
       boost::apply_visitor( boostache::detail::make_unwrap_variant_visitor(
-                               [&stream,&node](auto ctx)
+                               [&stream,&node](Context const & ctx)
                                {
                                   vm::detail::foreach(stream, node, ctx);
                                }

--- a/include/boost/boostache/vm/detail/select_context.hpp
+++ b/include/boost/boostache/vm/detail/select_context.hpp
@@ -51,8 +51,21 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       generate(stream, templ, ctx_child);
    }
-
-
+#ifdef BOOSTACHE_USE_CPP11
+   template<class Stream,class Temp, class ParentContext>
+   struct Cpp11GenericLamdaSimulation_select_with_parent_ctx
+   {
+       Stream& stream;
+       const Temp& templ;
+       const ParentContext& ctx_parent;
+       Cpp11GenericLamdaSimulation_select_with_parent_ctx(Stream& stream,const Temp& temp,const ParentContext& ctx_parent):stream(stream),templ(temp),ctx_parent(ctx_parent){}
+       template<class T>
+       void operator()(const T& ctx)const{
+           select_context( stream, templ, ctx_parent, ctx
+                         , extension::select_category_t<decltype(ctx)>{});
+       }
+   };
+#endif
    template < typename Stream, typename Template
             , typename Context1, typename Context2
             >
@@ -63,11 +76,16 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       boost::apply_visitor(
          boostache::detail::make_unwrap_variant_visitor(
-            [&stream,&templ,&ctx_parent](Context2 const & ctx)
+            #ifdef BOOSTACHE_USE_CPP11
+                Cpp11GenericLamdaSimulation_select_with_parent_ctx<Stream,Template,Context1>(stream,templ,ctx_parent)
+            #else
+            [&stream,&templ,&ctx_parent](auto ctx)
             {
                select_context( stream, templ, ctx_parent, ctx
                              , extension::select_category_t<decltype(ctx)>{});
-            })
+            }
+            #endif
+      )
           , ctx_child);
    }
 
@@ -80,6 +98,20 @@ namespace boost { namespace boostache { namespace vm { namespace detail
       generate(stream, templ.body, ctx);
    }
 
+#ifdef BOOSTACHE_USE_CPP11
+   template<class Stream,class Temp>
+   struct Cpp11GenericLamdaSimulation_select
+   {
+       Stream& stream;
+       const Temp& templ;
+       Cpp11GenericLamdaSimulation_select(Stream& stream,const Temp& temp):stream(stream),templ(temp){}
+       template<class T>
+       void operator()(const T& ctx)const{
+           select_context_dispatch( stream, templ, ctx
+                                  , extension::select_category_t<decltype(ctx)>{});
+       }
+   };
+#endif
 
    template <typename Stream, typename Context>
    void select_context_dispatch( Stream & stream
@@ -89,11 +121,16 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       boost::apply_visitor(
          boostache::detail::make_unwrap_variant_visitor(
-            [&stream,&templ](Context const & ctx)
+                #ifdef BOOSTACHE_USE_CPP11
+                   Cpp11GenericLamdaSimulation_select<Stream,ast::select_context>(stream,templ)
+                #else
+                    [&stream,&templ](auto ctx)
             {
                select_context_dispatch( stream, templ, ctx
                                       , extension::select_category_t<decltype(ctx)>{});
-            })
+            }
+                #endif
+      )
           , ctx);
    }
 

--- a/include/boost/boostache/vm/detail/select_context.hpp
+++ b/include/boost/boostache/vm/detail/select_context.hpp
@@ -63,7 +63,7 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       boost::apply_visitor(
          boostache::detail::make_unwrap_variant_visitor(
-            [&stream,&templ,&ctx_parent](auto ctx)
+            [&stream,&templ,&ctx_parent](Context2 const & ctx)
             {
                select_context( stream, templ, ctx_parent, ctx
                              , extension::select_category_t<decltype(ctx)>{});
@@ -89,7 +89,7 @@ namespace boost { namespace boostache { namespace vm { namespace detail
    {
       boost::apply_visitor(
          boostache::detail::make_unwrap_variant_visitor(
-            [&stream,&templ](auto ctx)
+            [&stream,&templ](Context const & ctx)
             {
                select_context_dispatch( stream, templ, ctx
                                       , extension::select_category_t<decltype(ctx)>{});

--- a/test/frontend/grammar_basic.cpp
+++ b/test/frontend/grammar_basic.cpp
@@ -17,6 +17,7 @@
 
 #include <sstream>
 #include <string>
+#include <boost/algorithm/cxx14/mismatch.hpp>
 
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
@@ -62,7 +63,7 @@ BOOST_AUTO_TEST_CASE(stache_parse_test)
       );
 
    auto input_ast = stream.str();
-   auto diff_iters = std::mismatch(input_ast.begin(), input_ast.end(),
+   auto diff_iters = boost::algorithm::mismatch(input_ast.begin(), input_ast.end(),
                                    expected.begin(), expected.end());
 
    if(std::get<0>(diff_iters) != input_ast.end())

--- a/test/shared/parser_test.cpp
+++ b/test/shared/parser_test.cpp
@@ -19,6 +19,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/parameterized_test.hpp>
+#include <boost/algorithm/cxx14/mismatch.hpp>
 #include <string>
 #include <fstream>
 #include <iostream>
@@ -49,7 +50,7 @@ void test_parse(std::string const & filename)
    std::string expected( std::istreambuf_iterator<char>{expect_stream}
                        , std::istreambuf_iterator<char>{});
 
-   auto diff_iters = std::mismatch(input_ast.begin(), input_ast.end(),
+   auto diff_iters = boost::algorithm::mismatch(input_ast.begin(), input_ast.end(),
                                    expected.begin(), expected.end());
 
    if(std::get<0>(diff_iters) != input_ast.end())


### PR DESCRIPTION
Changes for C++11 compatibility:

```
Replace auto with generic parameters in templates
std::mismatch -> boost::algorithm::mismatch (only tests affected)
```
